### PR TITLE
17 put or copy object

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,8 @@
 0.3.0 (08-08-2017)
 ------------------
 
-- Add 'copy' endpoint. Accepts the (augeias) location of the file object and copies it to a new location.
+- Add 'copy' functionality to update_object endpoint. In this case the view accepts the (augeias) location
+of the file object and copies it to a new location.
 
 0.2.0 (07-11-2015)
 ------------------

--- a/augeias/__init__.py
+++ b/augeias/__init__.py
@@ -21,15 +21,13 @@ def includeme(config):
                      pattern='/collections/{collection_key}/containers/{container_key}', request_method="GET")
     config.add_route('update_object', pattern='/collections/{collection_key}/containers/{container_key}/{object_key}',
                      request_method="PUT")
-    config.add_route('copy_object',
-                     pattern='/collections/{collection_key}/containers/{container_key}/{object_key}/copy-object',
-                     request_method="PUT")
     config.add_route('delete_object', pattern='/collections/{collection_key}/containers/{container_key}/{object_key}',
                      request_method="DELETE")
     config.add_route('get_object', pattern='/collections/{collection_key}/containers/{container_key}/{object_key}',
                      request_method="GET")
 
     config.scan()
+
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.

--- a/docs/service.rst
+++ b/docs/service.rst
@@ -292,6 +292,7 @@ container are 1 or more objects.
 
         PUT /collections/mine/containers/a311efb7-f125-4d0a-aa26-69d3657a2d06/circle HTTP/1.1
         Host: augeias.onroerenderfgoed.be
+        Content-Type: application/octet-stream
         Accept: application/json
 
     **Exmaple response**:
@@ -323,7 +324,7 @@ container are 1 or more objects.
     :statuscode 404: The collection `collection_key` or the container
         `container_key` does not exist.
 
-.. http:put:: /collections/{collection_key}/containers/{container_key}/{object_key}/copy-object
+.. http:put:: /collections/{collection_key}/containers/{container_key}/{object_key}
 
     Copy an object from one store location into another.
 
@@ -337,6 +338,7 @@ container are 1 or more objects.
 
         PUT /collections/mine/containers/a311efb7-f125-4d0a-aa26-69d3657a2d06/circle/copy-object HTTP/1.1
         Host: augeias.onroerenderfgoed.be
+        Content-Type: application/json
         Accept: application/json
 
         {

--- a/docs/service.rst
+++ b/docs/service.rst
@@ -336,7 +336,7 @@ container are 1 or more objects.
 
     .. sourcecode:: http
 
-        PUT /collections/mine/containers/a311efb7-f125-4d0a-aa26-69d3657a2d06/circle/copy-object HTTP/1.1
+        PUT /collections/mine/containers/a311efb7-f125-4d0a-aa26-69d3657a2d06/circle HTTP/1.1
         Host: augeias.onroerenderfgoed.be
         Content-Type: application/json
         Accept: application/json

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -176,7 +176,7 @@ class FunctionalTests(unittest.TestCase):
         self.assertEqual('200 OK', cres2.status)
         json_data = json.dumps(
             {'url': 'http://localhost/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID/200x300'})
-        ores2 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel/copy-object',
+        ores2 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel',
                                  json_data, headers={'content-type': 'application/json'})
 
         self.assertEqual('200 OK', ores2.status)
@@ -186,16 +186,16 @@ class FunctionalTests(unittest.TestCase):
 
     def test_copy_object_invalid_body(self):
         json_data = 'test'
-        res = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel/copy-object',
+        res = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel',
                                json_data, headers={'content-type': 'application/json'}, expect_errors=True)
         self.assertEqual(res.status, '400 Bad Request')
         json_data = '{"path": "test"}'
-        res3 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel/copy-object',
-                                json_data, expect_errors=True)
+        res3 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel',
+                                json_data, headers={'content-type': 'application/json'}, expect_errors=True)
         self.assertEqual(res3.status, '400 Bad Request')
         json_data = '{"url": "test"}'
-        res4 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel/copy-object',
-                                json_data, expect_errors=True)
+        res4 = self.testapp.put('/collections/TEST_COLLECTION/containers/TEST_CONTAINER_ID2/kasteel',
+                                json_data, headers={'content-type': 'application/json'}, expect_errors=True)
         self.assertEqual(res4.status, '400 Bad Request')
 
     def test_delete_object(self):


### PR DESCRIPTION
#17

- Add 'copy' functionality to update_object endpoint. In this case the view accepts the (augeias) location
of the file object and copies it to a new location.