### PR TITLE
Download zip of entire container.

### DIFF
--- a/augeias/__init__.py
+++ b/augeias/__init__.py
@@ -18,7 +18,11 @@ def includeme(config):
     config.add_route('delete_container', pattern='/collections/{collection_key}/containers/{container_key}',
                      request_method="DELETE")
     config.add_route('list_object_keys_for_container',
-                     pattern='/collections/{collection_key}/containers/{container_key}', request_method="GET")
+                     pattern='/collections/{collection_key}/containers/{container_key}', request_method="GET",
+                     accept='application/json')
+    config.add_route('get_container_data',
+                     pattern='/collections/{collection_key}/containers/{container_key}',
+                     request_method="GET", accept='application/zip')
     config.add_route('create_object_and_id', pattern='/collections/{collection_key}/containers/{container_key}',
                      request_method="POST")
     config.add_route('update_object', pattern='/collections/{collection_key}/containers/{container_key}/{object_key}',

--- a/augeias/stores/CephStore.py
+++ b/augeias/stores/CephStore.py
@@ -24,6 +24,9 @@ class CephStore(IStore):
     def update_object(self, container_key, object_key, object_data):
         pass
 
+    def get_container_data(self, container_key):
+        pass
+
     def create_container(self, container_key):
         pass
 

--- a/augeias/stores/StoreInterface.py
+++ b/augeias/stores/StoreInterface.py
@@ -77,6 +77,14 @@ class IStore:
         '''
 
     @abstractmethod
+    def get_container_data(self, container_key):
+        '''
+        Find a container and return a zip file of its contents.
+
+        :param container_key: Key of the container which must be retrieved.
+        :return: a zip file containing all files of the container.
+        '''
+    @abstractmethod
     def create_container(self, container_key):
         '''
         Create a new container in the data store.

--- a/augeias/views.py
+++ b/augeias/views.py
@@ -134,6 +134,19 @@ class AugeiasView(object):
         res.json_body = collection.object_store.list_object_keys_for_container(container_key)
         return res
 
+    @view_config(route_name='get_container_data', permission='view')
+    def get_container_data(self):
+        '''get a container from the data store'''
+        collection = _retrieve_collection(self.request)
+        container_key = self.request.matchdict['container_key']
+        zip_file = collection.object_store.get_container_data(container_key)
+        filename = str(container_key) + '.zip'
+        disposition = ('attachment; filename={}'.format(filename))
+        res = Response(content_type='application/zip', status=200,
+                       content_disposition=disposition)
+        res.body = zip_file.read()
+        return res
+
     @view_config(route_name='create_container', permission='edit')
     def create_container(self):
         '''create a new container in the data store'''


### PR DESCRIPTION
~~I can't run pytest with master branch either...~~
UPDATE: We'll have to upgrade the pytest version for tests to work on 2.7   --  an update from 3.6.0 to 3.6.1 is already enough (this commit fixes it https://github.com/pytest-dev/pytest/commit/b5a94d8e6c49201c8c79a7c52b8466e020e6d6b8)
Or we have to consider merging https://github.com/OnroerendErfgoed/augeias/pull/49

Little note:
I have no choice but to add a `accept=` on the existing `list_object_keys_for_container` route.
```
    config.add_route('list_object_keys_for_container',
                     pattern='/collections/{collection_key}/containers/{container_key}', request_method="GET")
```
I've set it to `application/json`. It doesn't affect the existing tests, and existing clients should only be affected if they were sending something else as an `Accept` header which would be strange.